### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/travis_cron/crons/views.py
+++ b/travis_cron/crons/views.py
@@ -32,7 +32,7 @@ def new(request):
         entry.full_clean()
         entry.save()
 
-        state = '%030x' % random.randrange(256**15)
+        state = '{0:030x}'.format(random.randrange(256**15))
         request.session['state'] = state
         request.session['entry_id'] = entry.id
         return HttpResponseRedirect('https://github.com/login/oauth/authorize?client_id={}&scope=public_repo&state={}'
@@ -79,7 +79,7 @@ def callback(request):
             entry.travis_token = travis_response['access_token']
             entry.save()
 
-            mail_message = "%s - %s\n\n%s\n\nSpecial requests:\n%s\n" % (entry.gh_project, entry.cronjob.description, 
+            mail_message = "{0!s} - {1!s}\n\n{2!s}\n\nSpecial requests:\n{3!s}\n".format(entry.gh_project, entry.cronjob.description, 
                                                                          entry.motivation, entry.special_requests or 'None :)')
             mail_admins('New entry!', mail_message)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:travis-cron?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:travis-cron?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
